### PR TITLE
Removed copyright from README in favour of NOTICE file

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ See [this thread](https://stackoverflow.com/questions/16383237/how-can-doc-docx-
 
 ## License
 
-Copyright 2019 JPMC
-
 Distributed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
 
 SPDX-License-Identifier: [Apache-2.0](https://spdx.org/licenses/Apache-2.0)


### PR DESCRIPTION
### Description
The contributor copyright notice `Copyright 2019 JPMC` has been removed from the project README in favour of `Copyright 2019 JPMC` that was originally added to the project NOTICE file.

https://github.com/finos/cloud-service-certification/blob/master/NOTICE

This PR is being raised as part of a housekeeping exercise on the repository as the Cloud Service Certification project ready themselves for further contribution.