### PR TITLE
Remove AWS copyright notice from Lambda and SQS Queue template

### DIFF
--- a/aws/lambda/lambda_template.yml
+++ b/aws/lambda/lambda_template.yml
@@ -1,7 +1,3 @@
-# (c) 2018 Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content
-# is provided subject to the terms of the AWS Customer Agreement available at
-# https://aws.amazon.com/agreement/ or other written agreement between Customer
-# and Amazon Web Services, Inc.
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'Lambda and SQS Queue template'
 


### PR DESCRIPTION
### Description

This PR is to remove the AWS copyright notice from `aws/lambda/lambda_template.yml` to reflect the same template format in `/aws/redshift/redshift_template_public.yml`

### Item that was removed 
```
# (c) 2018 Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content	
# is provided subject to the terms of the AWS Customer Agreement available at	
# https://aws.amazon.com/agreement/ or other written agreement between Customer	
# and Amazon Web Services, Inc.
```