### PR TITLE
Add GitHub Issue template for Cloud Service Certification meetings

### DIFF
--- a/.github/ISSUE_TEMPLATE/Meeting.md
+++ b/.github/ISSUE_TEMPLATE/Meeting.md
@@ -1,0 +1,43 @@
+---
+name: 🤝Cloud Service Certification Meeting Minutes
+about: To track Cloud Service Certification meeting agenda and attendance
+---
+
+## Date
+Thursday DD MMM yyyy - 10am EST
+
+## Untracked attendees
+- Fullname, Affiliation, (optional) GitHub username
+- ...
+
+## Agenda
+
+- [ ] Convene, roll call, welcome new people - 5 min
+- [ ] Review action items from previous meetings - 5 min
+- [ ] [Cloud Service Certification Kanban Review](https://github.com/orgs/finos/projects/1) - 5 min
+
+- [ ] _Add Items Here_
+
+- [ ] AOB, Q&A & Adjourn (5mins)
+
+## Decisions Made
+- [ ] Decision 1
+- [ ] Decision 2
+- [ ] ...
+
+## Action Items
+- [ ] Action 1
+- [ ] Action 2
+- [ ] ...
+
+### WebEx info
+**Webex:** 
+https://finos.webex.com/finos/j.php?MTID=me0b8e6061812f875505b0caaceac3321
+
+**Dial-in**
+**US** +1-415-655-0003 US Toll
+**UK** +44-20319-88141 UK Toll
+**Access code:** 662 732 581
+
+**Github Repo:** https://github.com/finos-fdx/cloud-service-certification/
+**Project Wiki Page:** https://finosfoundation.atlassian.net/wiki/spaces/FDX/pages/904626436/Cloud+Service+Certification+Project 


### PR DESCRIPTION
### Description
Add GitHub Issue template for creating and tracking Cloud Service Certification meeting agendas, minutes and attendance using GitHub issues.