### PR TITLE
Transfer markdown content from Cloud Service Certification wiki tab on GitHub into a docs folder in the repo

### DIFF
--- a/docs/open-roles/bdd-test-case-development-role.md
+++ b/docs/open-roles/bdd-test-case-development-role.md
@@ -1,3 +1,5 @@
+### BDD Test Case Development Role
+
 This role will create test cases using gherkin format or other project approved methods.  The purpose of this role is to translate the opinionated configurations from the Cloud Certification document into test cases formatted in the gherkin format.
 
 * **Who can perform this role:** Any project participant that can write or learn to write test cases in Gherkin format.  This is important because this method has been very powerful in achieving a cultural change between traditional security/compliance and application development teams.  This format also helps to clearly articulate the outcome of an action.

--- a/docs/open-roles/bdd-test-case-development-role.md
+++ b/docs/open-roles/bdd-test-case-development-role.md
@@ -1,6 +1,6 @@
 # BDD Test Case Development Role
 
-This role will create test cases using gherkin format or other project approved methods.  The purpose of this role is to translate the opinionated configurations from the Cloud Certification document into test cases formatted in the gherkin format.
+This role will create test cases using Gherkin format or other project approved methods.  The purpose of this role is to translate the opinionated configurations from the Cloud Certification document into test cases formatted in the gherkin format.
 
 * **Who can perform this role:** Any project participant that can write or learn to write test cases in Gherkin format.  This is important because this method has been very powerful in achieving a cultural change between traditional security/compliance and application development teams.  This format also helps to clearly articulate the outcome of an action.
 * **Product created:** Test cases written in gherkin format.  Test cases will need to be specific to positive and negative test cases

--- a/docs/open-roles/bdd-test-case-development-role.md
+++ b/docs/open-roles/bdd-test-case-development-role.md
@@ -1,4 +1,4 @@
-## BDD Test Case Development Role
+# BDD Test Case Development Role
 
 This role will create test cases using gherkin format or other project approved methods.  The purpose of this role is to translate the opinionated configurations from the Cloud Certification document into test cases formatted in the gherkin format.
 

--- a/docs/open-roles/bdd-test-case-development-role.md
+++ b/docs/open-roles/bdd-test-case-development-role.md
@@ -3,7 +3,7 @@
 This role will create test cases using Gherkin format or other project approved methods.  The purpose of this role is to translate the opinionated configurations from the Cloud Certification document into test cases formatted in the gherkin format.
 
 * **Who can perform this role:** Any project participant that can write or learn to write test cases in Gherkin format.  This is important because this method has been very powerful in achieving a cultural change between traditional security/compliance and application development teams.  This format also helps to clearly articulate the outcome of an action.
-* **Product created:** Test cases written in gherkin format.  Test cases will need to be specific to positive and negative test cases
+* **Product created:** Test cases written in Gherkin format.  Test cases will need to be specific to positive and negative test cases
 * **Skills required:** 
   * Writing user stories.  Gherkin is just a format that anyone with writing user stories can master in a few minutes.
   * Reviewing code and written controls to understand the outcome and actions required to be tested

--- a/docs/open-roles/bdd-test-case-development-role.md
+++ b/docs/open-roles/bdd-test-case-development-role.md
@@ -1,0 +1,8 @@
+This role will create test cases using gherkin format or other project approved methods.  The purpose of this role is to translate the opinionated configurations from the Cloud Certification document into test cases formatted in the gherkin format.
+
+* **Who can perform this role:** Any project participant that can write or learn to write test cases in Gherkin format.  This is important because this method has been very powerful in achieving a cultural change between traditional security/compliance and application development teams.  This format also helps to clearly articulate the outcome of an action.
+* **Product created:** Test cases written in gherkin format.  Test cases will need to be specific to positive and negative test cases
+* **Skills required:** 
+  * Writing user stories.  Gherkin is just a format that anyone with writing user stories can master in a few minutes.
+  * Reviewing code and written controls to understand the outcome and actions required to be tested
+  * Ability to use GitHub

--- a/docs/open-roles/bdd-test-case-development-role.md
+++ b/docs/open-roles/bdd-test-case-development-role.md
@@ -1,4 +1,4 @@
-### BDD Test Case Development Role
+## BDD Test Case Development Role
 
 This role will create test cases using gherkin format or other project approved methods.  The purpose of this role is to translate the opinionated configurations from the Cloud Certification document into test cases formatted in the gherkin format.
 

--- a/docs/open-roles/cloud-service-certification-documentation-role.md
+++ b/docs/open-roles/cloud-service-certification-documentation-role.md
@@ -1,4 +1,4 @@
-### Cloud Service Certification Documentation Role
+## Cloud Service Certification Documentation Role
 
 This role will research the specific Cloud Service and fill in the [document template](https://github.com/finos/cloud-service-certification/tree/master/templates) for each section making sure to provide specific technical examples and asserting an opinionated view of how to implement and meet the control objective.  This document will be vital to provide context to security teams, architecture review boards, internal compliance teams, developers, and infrastructure teams. 
 

--- a/docs/open-roles/cloud-service-certification-documentation-role.md
+++ b/docs/open-roles/cloud-service-certification-documentation-role.md
@@ -1,4 +1,4 @@
-## Cloud Service Certification Documentation Role
+# Cloud Service Certification Documentation Role
 
 This role will research the specific Cloud Service and fill in the [document template](https://github.com/finos/cloud-service-certification/tree/master/templates) for each section making sure to provide specific technical examples and asserting an opinionated view of how to implement and meet the control objective.  This document will be vital to provide context to security teams, architecture review boards, internal compliance teams, developers, and infrastructure teams. 
 

--- a/docs/open-roles/cloud-service-certification-documentation-role.md
+++ b/docs/open-roles/cloud-service-certification-documentation-role.md
@@ -1,3 +1,5 @@
+### Cloud Service Certification Documentation Role
+
 This role will research the specific Cloud Service and fill in the [document template](https://github.com/finos/cloud-service-certification/tree/master/templates) for each section making sure to provide specific technical examples and asserting an opinionated view of how to implement and meet the control objective.  This document will be vital to provide context to security teams, architecture review boards, internal compliance teams, developers, and infrastructure teams. 
 
 * **Product created:** A template document that includes detail of the service as related to categories specific to security and compliance (encryption, network, storage, availability, etc…)

--- a/docs/open-roles/cloud-service-certification-documentation-role.md
+++ b/docs/open-roles/cloud-service-certification-documentation-role.md
@@ -1,0 +1,9 @@
+This role will research the specific Cloud Service and fill in the [document template](https://github.com/finos/cloud-service-certification/tree/master/templates) for each section making sure to provide specific technical examples and asserting an opinionated view of how to implement and meet the control objective.  This document will be vital to provide context to security teams, architecture review boards, internal compliance teams, developers, and infrastructure teams. 
+
+* **Product created:** A template document that includes detail of the service as related to categories specific to security and compliance (encryption, network, storage, availability, etc…)
+* **Who can perform this role:** Any project participant that has strong technical security knowledge and has the relevant knowledge of the service in the document.  So if you have been using a service (i.e. S3) for a while you would be able to write the document.   If you are strong with a platform (Azure, Google, AWS) and just not a specific service it is likely you have the skills to write this document with a little research and time with the CSP product teams.
+* **Skills required**
+  * Strong technical security and compliance knowledge
+  * Deep knowledge of the cloud platform and specific service included in the document
+  * Ability to perform deployment and use the service on the platform to ensure recommendations are accurately represented and are effective.
+  * Ability to use GitHub

--- a/docs/open-roles/cloud-service-effort-owner.md
+++ b/docs/open-roles/cloud-service-effort-owner.md
@@ -1,4 +1,4 @@
-### Cloud Service Effort Owner Role
+## Cloud Service Effort Owner Role
 
 This role will perform the task of a coordinator to ensure participation is consistent and moving forward as well as to answer questions related to process or content format.  Typically, this role will held by one of the Cloud Service Certification effort role members.
 

--- a/docs/open-roles/cloud-service-effort-owner.md
+++ b/docs/open-roles/cloud-service-effort-owner.md
@@ -1,0 +1,10 @@
+This role will perform the task of a coordinator to ensure participation is consistent and moving forward as well as to answer questions related to process or content format.  Typically, this role will held by one of the Cloud Service Certification effort role members.
+
+* **Who can perform this role:** Any project participant
+* **Product created:** No tangible artefact. This is a coordination role.
+* **Skills required:** Depending on the artefact skills will vary
+  * Project management
+  * Document formatting and editing content
+  * Reviewing code for accuracy and efficacy
+  * Providing secondary opinion to affirm control settings meet regulatory requirement
+  * Ability to use GitHub

--- a/docs/open-roles/cloud-service-effort-owner.md
+++ b/docs/open-roles/cloud-service-effort-owner.md
@@ -1,3 +1,5 @@
+### Cloud Service Effort Owner Role
+
 This role will perform the task of a coordinator to ensure participation is consistent and moving forward as well as to answer questions related to process or content format.  Typically, this role will held by one of the Cloud Service Certification effort role members.
 
 * **Who can perform this role:** Any project participant

--- a/docs/open-roles/cloud-service-effort-owner.md
+++ b/docs/open-roles/cloud-service-effort-owner.md
@@ -1,4 +1,4 @@
-## Cloud Service Effort Owner Role
+# Cloud Service Effort Owner Role
 
 This role will perform the task of a coordinator to ensure participation is consistent and moving forward as well as to answer questions related to process or content format.  Typically, this role will held by one of the Cloud Service Certification effort role members.
 

--- a/docs/open-roles/codified-controls-development-role.md
+++ b/docs/open-roles/codified-controls-development-role.md
@@ -1,0 +1,6 @@
+* **Who can perform this role:**  any project participant that write code in a language like Terraform/python/java and can translate control language to code.
+* **Product created:**  Typically this will be a Terraform formatted code file that can represent the opinionated configurations of the Cloud Service Certification document in a codified way.   Other methods or formats are likely necessary and will be discovered through iterations of this product.
+* **Skills required:**  
+  * Writing code in Terraform/python/java
+  * Reviewing code for accuracy and efficacy
+  * Ability to use GitHub

--- a/docs/open-roles/codified-controls-development-role.md
+++ b/docs/open-roles/codified-controls-development-role.md
@@ -1,3 +1,5 @@
+### Codified Controls Development Role
+
 * **Who can perform this role:**  any project participant that write code in a language like Terraform/python/java and can translate control language to code.
 * **Product created:**  Typically this will be a Terraform formatted code file that can represent the opinionated configurations of the Cloud Service Certification document in a codified way.   Other methods or formats are likely necessary and will be discovered through iterations of this product.
 * **Skills required:**  

--- a/docs/open-roles/codified-controls-development-role.md
+++ b/docs/open-roles/codified-controls-development-role.md
@@ -1,4 +1,4 @@
-## Codified Controls Development Role
+# Codified Controls Development Role
 
 * **Who can perform this role:**  any project participant that write code in a language like Terraform/python/java and can translate control language to code.
 * **Product created:**  Typically this will be a Terraform formatted code file that can represent the opinionated configurations of the Cloud Service Certification document in a codified way.   Other methods or formats are likely necessary and will be discovered through iterations of this product.

--- a/docs/open-roles/codified-controls-development-role.md
+++ b/docs/open-roles/codified-controls-development-role.md
@@ -1,4 +1,4 @@
-### Codified Controls Development Role
+## Codified Controls Development Role
 
 * **Who can perform this role:**  any project participant that write code in a language like Terraform/python/java and can translate control language to code.
 * **Product created:**  Typically this will be a Terraform formatted code file that can represent the opinionated configurations of the Cloud Service Certification document in a codified way.   Other methods or formats are likely necessary and will be discovered through iterations of this product.

--- a/docs/open-roles/codified-controls-development-role.md
+++ b/docs/open-roles/codified-controls-development-role.md
@@ -3,6 +3,6 @@
 * **Who can perform this role:**  any project participant that write code in a language like Terraform/python/java and can translate control language to code.
 * **Product created:**  Typically this will be a Terraform formatted code file that can represent the opinionated configurations of the Cloud Service Certification document in a codified way.   Other methods or formats are likely necessary and will be discovered through iterations of this product.
 * **Skills required:**  
-  * Writing code in Terraform/python/java
+  * Writing code in Terraform/Python/Java
   * Reviewing code for accuracy and efficacy
   * Ability to use GitHub

--- a/docs/open-roles/codified-controls-development-role.md
+++ b/docs/open-roles/codified-controls-development-role.md
@@ -1,6 +1,6 @@
 # Codified Controls Development Role
 
-* **Who can perform this role:**  any project participant that write code in a language like Terraform/python/java and can translate control language to code.
+* **Who can perform this role:**  any project participant that write code in a language like Terraform/Python/Java and can translate control language to code.
 * **Product created:**  Typically this will be a Terraform formatted code file that can represent the opinionated configurations of the Cloud Service Certification document in a codified way.   Other methods or formats are likely necessary and will be discovered through iterations of this product.
 * **Skills required:**  
   * Writing code in Terraform/Python/Java

--- a/docs/open-roles/compliance-framework-mapping-role.md
+++ b/docs/open-roles/compliance-framework-mapping-role.md
@@ -1,3 +1,5 @@
+### Compliance Framework Mapping Role
+
 This role will coordinate with other volunteers and the Working Group to identify common control frameworks for which content will be measured against.
 
 * **Product created:** A spreadsheet that has clear definition of control framework requirement including detail on how technical implementation would meet the requirement.

--- a/docs/open-roles/compliance-framework-mapping-role.md
+++ b/docs/open-roles/compliance-framework-mapping-role.md
@@ -1,0 +1,8 @@
+This role will coordinate with other volunteers and the Working Group to identify common control frameworks for which content will be measured against.
+
+* **Product created:** A spreadsheet that has clear definition of control framework requirement including detail on how technical implementation would meet the requirement.
+* **Who can perform this role:** Any project participant with compliance responsibility within their organization and can speak authoritatively on how to meet compliance within the specified control framework within the financial services industry.
+* **Skills required**
+  * Identifying controls within financial services relevant frameworks
+  * Documenting controls and including clear technical definition of actions required to meet control requirement
+  * Ability to use GitHub

--- a/docs/open-roles/compliance-framework-mapping-role.md
+++ b/docs/open-roles/compliance-framework-mapping-role.md
@@ -1,4 +1,4 @@
-### Compliance Framework Mapping Role
+## Compliance Framework Mapping Role
 
 This role will coordinate with other volunteers and the Working Group to identify common control frameworks for which content will be measured against.
 

--- a/docs/open-roles/compliance-framework-mapping-role.md
+++ b/docs/open-roles/compliance-framework-mapping-role.md
@@ -1,4 +1,4 @@
-## Compliance Framework Mapping Role
+# Compliance Framework Mapping Role
 
 This role will coordinate with other volunteers and the Working Group to identify common control frameworks for which content will be measured against.
 

--- a/docs/open-roles/peer-reviewer-role.md
+++ b/docs/open-roles/peer-reviewer-role.md
@@ -1,0 +1,8 @@
+This role will perform the review of the proposed content and ensure high levels of content quality, consistency with the template, accuracy to technical detail, and fit and finish for public GitHub repo commit.
+
+* **Who can perform this role:** Any project participant that has the specific skills necessary for the artefact being reviewed.
+* **Product created:** Written opinion of efficacy of control.  Positive opinion will trigger commit actions for artefacts being reviewed to GitHub repo.
+* **Skills required:**
+  * Document formatting and editing content
+  * Reviewing code for accuracy and efficacy
+  * Providing secondary opinion to affirm control settings meet regulatory requirement

--- a/docs/open-roles/peer-reviewer-role.md
+++ b/docs/open-roles/peer-reviewer-role.md
@@ -1,4 +1,4 @@
-## Peer Review Role
+# Peer Review Role
 
 This role will perform the review of the proposed content and ensure high levels of content quality, consistency with the template, accuracy to technical detail, and fit and finish for public GitHub repo commit.
 

--- a/docs/open-roles/peer-reviewer-role.md
+++ b/docs/open-roles/peer-reviewer-role.md
@@ -1,4 +1,4 @@
-### Peer Review Role
+## Peer Review Role
 
 This role will perform the review of the proposed content and ensure high levels of content quality, consistency with the template, accuracy to technical detail, and fit and finish for public GitHub repo commit.
 

--- a/docs/open-roles/peer-reviewer-role.md
+++ b/docs/open-roles/peer-reviewer-role.md
@@ -1,3 +1,5 @@
+### Peer Review Role
+
 This role will perform the review of the proposed content and ensure high levels of content quality, consistency with the template, accuracy to technical detail, and fit and finish for public GitHub repo commit.
 
 * **Who can perform this role:** Any project participant that has the specific skills necessary for the artefact being reviewed.

--- a/docs/open-volunteer-roles.md
+++ b/docs/open-volunteer-roles.md
@@ -1,4 +1,4 @@
-## Open Volunteer Roles
+# Open Volunteer Roles
 
 The following is a list of the open Cloud Service Certification volunteer roles.
 

--- a/docs/open-volunteer-roles.md
+++ b/docs/open-volunteer-roles.md
@@ -1,8 +1,8 @@
 The following is a list of the open Cloud Service Certification volunteer roles.
 
-* [Compliance Framework Mapping Role](https://github.com/finos/cloud-service-certification/wiki/Compliance-Framework-Mapping-Role)
-* [Cloud Service Certification Documentation Role](https://github.com/finos/cloud-service-certification/wiki/Cloud-Service-Certification-Documentation-Role)
-* [Codified Controls Development Role](https://github.com/finos/cloud-service-certification/wiki/Codified-Controls-Development-Role)
-* [BDD Test Case Development Role](https://github.com/finos/cloud-service-certification/wiki/BDD-Test-Case-Development-Role)
-* [Peer Reviewer Role](https://github.com/finos/cloud-service-certification/wiki/Peer-Reviewer-Role)
-* [Cloud Service Effort Owner](https://github.com/finos/cloud-service-certification/wiki/Cloud-Service-Effort-Owner)
+* [Compliance Framework Mapping Role](compliance-framework-mapping-role.md)
+* [Cloud Service Certification Documentation Role](cloud-service-certification-documentation-role.md)
+* [Codified Controls Development Role](codified-controls-development-role.md)
+* [BDD Test Case Development Role](bdd-test-case-development-role.md)
+* [Peer Reviewer Role](peer-reviewer-role.md)
+* [Cloud Service Effort Owner](cloud-service-effort-owner.md)

--- a/docs/open-volunteer-roles.md
+++ b/docs/open-volunteer-roles.md
@@ -1,4 +1,4 @@
-### Open Volunteer Roles
+## Open Volunteer Roles
 
 The following is a list of the open Cloud Service Certification volunteer roles.
 

--- a/docs/open-volunteer-roles.md
+++ b/docs/open-volunteer-roles.md
@@ -1,0 +1,8 @@
+The following is a list of the open Cloud Service Certification volunteer roles.
+
+* [Compliance Framework Mapping Role](https://github.com/finos/cloud-service-certification/wiki/Compliance-Framework-Mapping-Role)
+* [Cloud Service Certification Documentation Role](https://github.com/finos/cloud-service-certification/wiki/Cloud-Service-Certification-Documentation-Role)
+* [Codified Controls Development Role](https://github.com/finos/cloud-service-certification/wiki/Codified-Controls-Development-Role)
+* [BDD Test Case Development Role](https://github.com/finos/cloud-service-certification/wiki/BDD-Test-Case-Development-Role)
+* [Peer Reviewer Role](https://github.com/finos/cloud-service-certification/wiki/Peer-Reviewer-Role)
+* [Cloud Service Effort Owner](https://github.com/finos/cloud-service-certification/wiki/Cloud-Service-Effort-Owner)

--- a/docs/open-volunteer-roles.md
+++ b/docs/open-volunteer-roles.md
@@ -1,8 +1,8 @@
 The following is a list of the open Cloud Service Certification volunteer roles.
 
-* [Compliance Framework Mapping Role](compliance-framework-mapping-role.md)
-* [Cloud Service Certification Documentation Role](cloud-service-certification-documentation-role.md)
-* [Codified Controls Development Role](codified-controls-development-role.md)
-* [BDD Test Case Development Role](bdd-test-case-development-role.md)
-* [Peer Reviewer Role](peer-reviewer-role.md)
-* [Cloud Service Effort Owner](cloud-service-effort-owner.md)
+* [Compliance Framework Mapping Role](open-roles/compliance-framework-mapping-role.md)
+* [Cloud Service Certification Documentation Role](open-roles/cloud-service-certification-documentation-role.md)
+* [Codified Controls Development Role](open-roles/codified-controls-development-role.md)
+* [BDD Test Case Development Role](open-roles/bdd-test-case-development-role.md)
+* [Peer Reviewer Role](open-roles/peer-reviewer-role.md)
+* [Cloud Service Effort Owner](open-roles/cloud-service-effort-owner.md)

--- a/docs/open-volunteer-roles.md
+++ b/docs/open-volunteer-roles.md
@@ -1,3 +1,5 @@
+### Open Volunteer Roles
+
 The following is a list of the open Cloud Service Certification volunteer roles.
 
 * [Compliance Framework Mapping Role](open-roles/compliance-framework-mapping-role.md)

--- a/docs/project-charter.md
+++ b/docs/project-charter.md
@@ -19,7 +19,7 @@ The working group will produce multiple Cloud Service Certification artifacts (t
 
 ## [Open Volunteer Roles](open-volunteer-roles.md)
 * [Compliance Framework Mapping Role](open-roles/compliance-framework-mapping-role.md)
-* [Cloud Service Certification Documentation Role](open-roles/cloud-service-certification-documentation-role)
+* [Cloud Service Certification Documentation Role](open-roles/cloud-service-certification-documentation-role.md)
 * [Codified Controls Development Role](/codified-controls-development-role.md)
 * [BDD Test Case Development Role](open-roles/bdd-test-case-development-role.md)
 * [Peer Reviewer Role](open-roles/peer-reviewer-role.md)

--- a/docs/project-charter.md
+++ b/docs/project-charter.md
@@ -28,7 +28,7 @@ The working group will produce multiple Cloud Service Certification artifacts (t
 # Group Information
 * **Meetings and Minutes**
   * [Meetings and Minutes on GitHub](https://github.com/finos/cloud-service-certification/issues?q=label%3Ameeting+)
-  * [*Depricated Meeting and Minutes on Confluence*](https://finosfoundation.atlassian.net/wiki/spaces/FDX/pages/917962769/Minutes)
+  * [*Deprecated Meeting and Minutes on Confluence*](https://finosfoundation.atlassian.net/wiki/spaces/FDX/pages/917962769/Minutes)
 * **Mailing list:** [fdx-cloud-service-certification@finos.org](mailto:fdx-cloud-service-certification@finos.org) ([web archive](https://groups.google.com/a/finos.org/forum/#!forum/fdx-cloud-service-certification))
 * **Google Group**: [https://groups.google.com/a/finos.org/forum/#!topic/fdx-cloud-service-certification/1RPUvv18ksA](https://groups.google.com/a/finos.org/forum/#!topic/fdx-cloud-service-certification/1RPUvv18ksA)
 

--- a/docs/project-charter.md
+++ b/docs/project-charter.md
@@ -20,7 +20,7 @@ The working group will produce multiple Cloud Service Certification artifacts (t
 ## [Open Volunteer Roles](open-volunteer-roles.md)
 * [Compliance Framework Mapping Role](open-roles/compliance-framework-mapping-role.md)
 * [Cloud Service Certification Documentation Role](open-roles/cloud-service-certification-documentation-role.md)
-* [Codified Controls Development Role](/codified-controls-development-role.md)
+* [Codified Controls Development Role](open-roles/codified-controls-development-role.md)
 * [BDD Test Case Development Role](open-roles/bdd-test-case-development-role.md)
 * [Peer Reviewer Role](open-roles/peer-reviewer-role.md)
 * [Cloud Service Effort Owner](open-roles/cloud-service-effort-owner.md)

--- a/docs/project-charter.md
+++ b/docs/project-charter.md
@@ -65,8 +65,8 @@ Original Contribution JIRA: [https://finosfoundation.atlassian.net/browse/CONTRI
 
 (**) indicates FINOS member
 
-## Documentation Links
+## Documentation Links and Resources
 * [Cloud Service Certification PDF](https://finosfoundation.atlassian.net/wiki/download/attachments/904626436/2019.2.19%20-%20FINOS%20Cloud%20Certification%20contribution%20by%20JPMC.pdf?version=1&modificationDate=1560439158668&cacheVersion=1&api=v2)
-* [cloud Security Alliance](https://cloudsecurityalliance.org/)
+* [Cloud Security Alliance](https://cloudsecurityalliance.org/)
   * https://cloudsecurityalliance.org/research/artifacts/
   * https://cloudsecurityalliance.org/research/artifacts/?search=&char=&term=cloud-security-services-management&locale=en

--- a/docs/project-charter.md
+++ b/docs/project-charter.md
@@ -26,7 +26,8 @@ The working group will produce multiple Cloud Service Certification artifacts (t
 * [Cloud Service Effort Owner](open-roles/cloud-service-effort-owner.md)
 
 # Group Information
-* [Minutes](https://finosfoundation.atlassian.net/wiki/spaces/FDX/pages/917962769/Minutes)
+* [Meetings and Minutes on GitHub](https://github.com/finos/cloud-service-certification/issues?q=label%3Ameeting+)
+* [Depricated Meeting and Minutes on Confluence](https://finosfoundation.atlassian.net/wiki/spaces/FDX/pages/917962769/Minutes)
 * **Mailing list:** [fdx-cloud-service-certification@finos.org](mailto:fdx-cloud-service-certification@finos.org) ([web archive](https://groups.google.com/a/finos.org/forum/#!forum/fdx-cloud-service-certification))
 * **Google Group**: [https://groups.google.com/a/finos.org/forum/#!topic/fdx-cloud-service-certification/1RPUvv18ksA](https://groups.google.com/a/finos.org/forum/#!topic/fdx-cloud-service-certification/1RPUvv18ksA)
 

--- a/docs/project-charter.md
+++ b/docs/project-charter.md
@@ -67,3 +67,6 @@ Original Contribution JIRA: [https://finosfoundation.atlassian.net/browse/CONTRI
 
 ## Documentation Links
 * [Cloud Service Certification PDF](https://finosfoundation.atlassian.net/wiki/download/attachments/904626436/2019.2.19%20-%20FINOS%20Cloud%20Certification%20contribution%20by%20JPMC.pdf?version=1&modificationDate=1560439158668&cacheVersion=1&api=v2)
+* [cloud Security Alliance](https://cloudsecurityalliance.org/)
+  * https://cloudsecurityalliance.org/research/artifacts/
+  * https://cloudsecurityalliance.org/research/artifacts/?search=&char=&term=cloud-security-services-management&locale=en

--- a/docs/project-charter.md
+++ b/docs/project-charter.md
@@ -65,5 +65,5 @@ Original Contribution JIRA: [https://finosfoundation.atlassian.net/browse/CONTRI
 
 (**) indicates FINOS member
 
-
-
+## Documentation Links
+* [Cloud Service Certification PDF](https://finosfoundation.atlassian.net/wiki/download/attachments/904626436/2019.2.19%20-%20FINOS%20Cloud%20Certification%20contribution%20by%20JPMC.pdf?version=1&modificationDate=1560439158668&cacheVersion=1&api=v2)

--- a/docs/project-charter.md
+++ b/docs/project-charter.md
@@ -1,0 +1,67 @@
+# Project Charter
+## Mission
+The mission of the Cloud Service Certification Working Group is to accelerate the development, deployment, and adoption of a common set of controls and tests for cloud services.
+
+## Business Problem and Opportunity
+Cloud services controls and tests are used to demonstrate adherence with regulatory and internal compliance requirements mandated for financial institutions when using cloud services. The majority of cloud security incidents are due to misconfiguration; services are not secure by default, configuration is often complex, nuanced and difficult to validate. To some degree or another all financial institutions are re-inventing the wheel – institutions have similar control frameworks and each is trying to secure and stand up the same providers and services within the same regulatory frameworks.
+
+Having robust controls and tests developed and in place removes a barrier to faster adoption of cloud services such as those provided by Amazon/AWS, Microsoft/Azure and Google/GCP, among others. Addressing this barrier will benefit both financial services IT departments, many of whom are looking to move more quickly to the cloud, and the providers themselves, who wish to sell more cloud services into financial institutions. 
+
+Controls for cloud service compliance afford banks no particular strategic or competitive advantage while also representing a task something all banks who look to deploy more applications onto the cloud needs to do, and as such are conducive to being developed together as part of the "public commons". The focused project and collaboration with other banks will increase the amount of controls produced and, it's expected, help increase the rate of adoption of cloud services.
+
+## Approach and Proposed Solution
+The working group will produce multiple Cloud Service Certification artifacts (together forming one or multiple accelerators) that provide functional code that implements regulatory compliant configurations of cloud services with BDD tests to validate efficacy.  The group review the artifacts for an accelerator and then gather feedback on process and content before iterating on additional services. A key part of the working group's approach will be to set quality standards across artifacts; members of all tiers can contribute to the project and ensure a common high level of quality is delivered and in less time. The group will also work with cloud service providers to produce more industry specific content and solutions. 
+
+## Launch
+* Kick off meeting to review existing artifacts and state outcomes and expectations which will include assignments of tasks.
+* Hold biweekly (2 week interval) meetings to do show 'n tell and determine fitness.  We will have this mailing list to communicate more frequently as well.
+* Within 1 month (2 meetings) we will determine fitness of work and begin peer review if enough content is complete.
+
+## [Open Volunteer Roles](open-volunteer-roles.md)
+* [Compliance Framework Mapping Role](open-roles/compliance-framework-mapping-role.md)
+* [Cloud Service Certification Documentation Role](open-roles/cloud-service-certification-documentation-role)
+* [Codified Controls Development Role](/codified-controls-development-role.md)
+* [BDD Test Case Development Role](open-roles/bdd-test-case-development-role.md)
+* [Peer Reviewer Role](open-roles/peer-reviewer-role.md)
+* [Cloud Service Effort Owner](open-roles/cloud-service-effort-owner.md)
+
+# Group Information
+* [Minutes](https://finosfoundation.atlassian.net/wiki/spaces/FDX/pages/917962769/Minutes)
+* **Mailing list:** [fdx-cloud-service-certification@finos.org](mailto:fdx-cloud-service-certification@finos.org) ([web archive](https://groups.google.com/a/finos.org/forum/#!forum/fdx-cloud-service-certification))
+* **Google Group**: [https://groups.google.com/a/finos.org/forum/#!topic/fdx-cloud-service-certification/1RPUvv18ksA](https://groups.google.com/a/finos.org/forum/#!topic/fdx-cloud-service-certification/1RPUvv18ksA)
+
+* **Meetings**
+
+  * **Schedule:** Group meets every other Thursday at 10am ET / 3pm London.
+
+  * **Next Meeting:** Next meeting **Thursday 30th January 2020**
+
+  * **Webex:** [https://finos.webex.com/finos/j.php?MTID=me0b8e6061812f875505b0caaceac3321](https://finos.webex.com/finos/j.php?MTID=me0b8e6061812f875505b0caaceac3321)
+  * **Dial-in:** 
+
+    * +1-415-655-0003 US Toll
+    * +44-20319-88141 UK Toll
+    * Access code: 662 732 581
+
+Github Repository: [https://github.com/finos-fdx/cloud-service-certification](https://github.com/finos-fdx/cloud-service-certification)
+
+Original Contribution JIRA: [https://finosfoundation.atlassian.net/browse/CONTRIB-33](https://finosfoundation.atlassian.net/browse/CONTRIB-33)
+
+## Project Participants
+| Name             | Organization      | Role         | GitHub ID        |
+| ---------------- | ----------------- | ------------ | ---------------- |
+| Jason Nelson     | JPMC**            | Chair        | [git-hub-forwork1](https://github.com/git-hub-forwork1) |
+| James McLeod     | FINOS             | Participant  | [mcleo-d](https://github.com/mcleo-d) |
+| Jonathan Meadows | JPMC**            | Participant  |                  |	
+| Gavin Manning    | DB**              | Participant  |                  |
+| Colin May        | Credit Suisse**   | Participant  |                  |
+| Astha Malik      | Microsoft         | Participant  |                  |
+| Abdullah Garcia  | JPMC**            | Participant  |                  |
+| Jonathan Hodgson | Morgan Stanley ** | Participant  |                  |
+| Stuart Buckland  | UBS**             | Participant  |                  |
+| Jonathan Altman  | CapitalOne**      | Participant  |                  |
+
+(**) indicates FINOS member
+
+
+

--- a/docs/project-charter.md
+++ b/docs/project-charter.md
@@ -26,8 +26,9 @@ The working group will produce multiple Cloud Service Certification artifacts (t
 * [Cloud Service Effort Owner](open-roles/cloud-service-effort-owner.md)
 
 # Group Information
-* [Meetings and Minutes on GitHub](https://github.com/finos/cloud-service-certification/issues?q=label%3Ameeting+)
-* [Depricated Meeting and Minutes on Confluence](https://finosfoundation.atlassian.net/wiki/spaces/FDX/pages/917962769/Minutes)
+* **Meetings and Minutes**
+  * [Meetings and Minutes on GitHub](https://github.com/finos/cloud-service-certification/issues?q=label%3Ameeting+)
+  * [Depricated Meeting and Minutes on Confluence](https://finosfoundation.atlassian.net/wiki/spaces/FDX/pages/917962769/Minutes)
 * **Mailing list:** [fdx-cloud-service-certification@finos.org](mailto:fdx-cloud-service-certification@finos.org) ([web archive](https://groups.google.com/a/finos.org/forum/#!forum/fdx-cloud-service-certification))
 * **Google Group**: [https://groups.google.com/a/finos.org/forum/#!topic/fdx-cloud-service-certification/1RPUvv18ksA](https://groups.google.com/a/finos.org/forum/#!topic/fdx-cloud-service-certification/1RPUvv18ksA)
 

--- a/docs/project-charter.md
+++ b/docs/project-charter.md
@@ -45,7 +45,7 @@ The working group will produce multiple Cloud Service Certification artifacts (t
     * +44-20319-88141 UK Toll
     * Access code: 662 732 581
 
-Github Repository: [https://github.com/finos-fdx/cloud-service-certification](https://github.com/finos/cloud-service-certification)
+Github Repository: [https://github.com/finos/cloud-service-certification](https://github.com/finos/cloud-service-certification)
 
 Original Contribution JIRA: [https://finosfoundation.atlassian.net/browse/CONTRIB-33](https://finosfoundation.atlassian.net/browse/CONTRIB-33)
 

--- a/docs/project-charter.md
+++ b/docs/project-charter.md
@@ -45,7 +45,7 @@ The working group will produce multiple Cloud Service Certification artifacts (t
     * +44-20319-88141 UK Toll
     * Access code: 662 732 581
 
-Github Repository: [https://github.com/finos-fdx/cloud-service-certification](https://github.com/finos-fdx/cloud-service-certification)
+Github Repository: [https://github.com/finos-fdx/cloud-service-certification](https://github.com/finos/cloud-service-certification)
 
 Original Contribution JIRA: [https://finosfoundation.atlassian.net/browse/CONTRIB-33](https://finosfoundation.atlassian.net/browse/CONTRIB-33)
 

--- a/docs/project-charter.md
+++ b/docs/project-charter.md
@@ -28,7 +28,7 @@ The working group will produce multiple Cloud Service Certification artifacts (t
 # Group Information
 * **Meetings and Minutes**
   * [Meetings and Minutes on GitHub](https://github.com/finos/cloud-service-certification/issues?q=label%3Ameeting+)
-  * [Depricated Meeting and Minutes on Confluence](https://finosfoundation.atlassian.net/wiki/spaces/FDX/pages/917962769/Minutes)
+  * [*Depricated Meeting and Minutes on Confluence*](https://finosfoundation.atlassian.net/wiki/spaces/FDX/pages/917962769/Minutes)
 * **Mailing list:** [fdx-cloud-service-certification@finos.org](mailto:fdx-cloud-service-certification@finos.org) ([web archive](https://groups.google.com/a/finos.org/forum/#!forum/fdx-cloud-service-certification))
 * **Google Group**: [https://groups.google.com/a/finos.org/forum/#!topic/fdx-cloud-service-certification/1RPUvv18ksA](https://groups.google.com/a/finos.org/forum/#!topic/fdx-cloud-service-certification/1RPUvv18ksA)
 


### PR DESCRIPTION
## Description
The Cloud Service Certification wiki is currently hosted behind the [CSC GitHub Wiki tab](https://github.com/finos/cloud-service-certification/wiki), which means pull requests cannot be raised in order to add or update wiki markdown content. 

This pull request transfers the markdown content of the CSC Wiki into a `docs` folder that reflects the following structure so the CSC project can take ownership of project content without editorial rights permissions.

## Proposed Initial Wiki Structure

```
|__ docs
    |__ open-roles
        |__ bdd-test-case-development-role.md
        |__ cloud-service-certification-documentation-role.md
        |__ cloud-service-effort-owner.md
        |__ codified-controls-development-role.md
        |__ compliance-framework-mapping-role.md
        |__ peer-reviewer-role.md
    |__ open-volunteer-roles.md
    |__ project-charter.md
```

### This PR Resolves
* closes #16