### PR TITLE
Replacing deprecated set-env command

### DIFF
--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -72,7 +72,7 @@ jobs:
         if [ -f "metadata-tool/github-finos-meetings-unknowns.txt" ]; then
           UNKNOWNS=`cat metadata-tool/github-finos-meetings-unknowns.txt`
           ISSUE_CONTENT="Couldn't find the following GitHub usernames on file: ${UNKNOWNS} . /CC @aitana16 @maoo @mcleo-d"
-          echo "::set-env name=UNKNOWNS_COMMENT::${ISSUE_CONTENT}"
+          echo "${ISSUE_CONTENT}" >> $UNKNOWNS_COMMENT
           echo "Posting message as comment: ${UNKNOWNS_COMMENT}"
         fi
     - name: Report unknowns on issue comment


### PR DESCRIPTION
This should fix the action error on https://github.com/finos/cloud-service-certification/actions/runs/370781622

I followed indications found on https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

Could you please merge this PR and try to re-run the failed action please?