### PR TITLE
Use terraform fmt for canonical terraform formatting

### DIFF
--- a/gcp/gke/gke-terraform-scripts/main.tf
+++ b/gcp/gke/gke-terraform-scripts/main.tf
@@ -1,13 +1,13 @@
-provider "google"{
-    credentials= file(var.cred_url)
-    project= var.project_id
-    region= var.region
+provider "google" {
+  credentials = file(var.cred_url)
+  project     = var.project_id
+  region      = var.region
 }
- 
+
 // VPC and firewall creation 
 
 resource "google_compute_network" "gke-vpc" {
-  name = var.gke-vpc.name
+  name                    = var.gke-vpc.name
   auto_create_subnetworks = "false"
 }
 
@@ -20,63 +20,63 @@ resource "google_compute_firewall" "allow-iap" {
     protocol = "tcp"
     ports    = ["22"]
   }
-    
+
   source_ranges = ["35.235.240.0/20"]
-  target_tags = ["allow-iap"]
- }
+  target_tags   = ["allow-iap"]
+}
 
 
 //Subnets creation for gke-vpc
 
-module "admin-subnet"{
+module "admin-subnet" {
   source        = "./modules/subnetwork"
   name          = var.gke-vpc.subnets[0].name
   description   = var.gke-vpc.subnets[0].description
   ip_cidr_range = var.gke-vpc.subnets[0].ip_cidr_range
   region        = var.gke-vpc.subnets[0].region
-  network       = "${google_compute_network.gke-vpc.self_link}"
+  network       = google_compute_network.gke-vpc.self_link
 }
 
-module "k8s-subnet"{
+module "k8s-subnet" {
   source        = "./modules/subnetwork"
   name          = var.gke-vpc.subnets[1].name
   description   = var.gke-vpc.subnets[1].description
   ip_cidr_range = var.gke-vpc.subnets[1].ip_cidr_range
   region        = var.gke-vpc.subnets[1].region
-  network       = "${google_compute_network.gke-vpc.self_link}"
+  network       = google_compute_network.gke-vpc.self_link
 }
 
 //bastion host for gke-vpc
 
 module "bastion-host" {
-  source              = "./modules/Bastion_Host"
-  project_id          = var.project_id
-  bastion_subnet_name = var.gke-vpc.subnets[0].name
-  internal_ip_address = var.bastion_host.internal_ip_address
-  vm_name             = var.bastion_host.vm_name
-  machine_type        = var.bastion_host.machine_type
-  zone                = var.bastion_host.zone
-  machine_image       = var.bastion_host.machine_image
-  tags                = var.bastion_host.tags
-  static-internal-ip-name= "bastion-ip"
-  region             = var.bastion_host.region
+  source                  = "./modules/Bastion_Host"
+  project_id              = var.project_id
+  bastion_subnet_name     = var.gke-vpc.subnets[0].name
+  internal_ip_address     = var.bastion_host.internal_ip_address
+  vm_name                 = var.bastion_host.vm_name
+  machine_type            = var.bastion_host.machine_type
+  zone                    = var.bastion_host.zone
+  machine_image           = var.bastion_host.machine_image
+  tags                    = var.bastion_host.tags
+  static-internal-ip-name = "bastion-ip"
+  region                  = var.bastion_host.region
 }
 
 //GKE Cluster 
 
 module "gke-cluster" {
-  source                = "./modules/kubernetes"
-  project_id            = var.project_id
-  service_account_name  = var.gke-cluster.service_account_name
-  region                = var.gke-cluster.region
-  cluster_name          = var.gke-cluster.cluster_name
-  vpc_name              = google_compute_network.gke-vpc.name
-  subnet_name           = var.gke-vpc.subnets[1].name
-  bastion_ip            = "${var.bastion_host.internal_ip_address}/32"
-  master_cidr           = var.gke-cluster.master_cidr 
+  source                  = "./modules/kubernetes"
+  project_id              = var.project_id
+  service_account_name    = var.gke-cluster.service_account_name
+  region                  = var.gke-cluster.region
+  cluster_name            = var.gke-cluster.cluster_name
+  vpc_name                = google_compute_network.gke-vpc.name
+  subnet_name             = var.gke-vpc.subnets[1].name
+  bastion_ip              = "${var.bastion_host.internal_ip_address}/32"
+  master_cidr             = var.gke-cluster.master_cidr
   cluster_ipv4_cidr_block = var.gke-cluster.cluster_ipv4_cidr_block
-  machine_type = var.gke-cluster.machine_type
-  encryption_key_name  = var.encryption_key_name
- }
+  machine_type            = var.gke-cluster.machine_type
+  encryption_key_name     = var.encryption_key_name
+}
 
- 
+

--- a/gcp/gke/gke-terraform-scripts/modules/Bastion_Host/main.tf
+++ b/gcp/gke/gke-terraform-scripts/modules/Bastion_Host/main.tf
@@ -3,7 +3,7 @@ resource "google_compute_address" "bastion_internal_ip" {
   address_type = "INTERNAL"
   address      = var.internal_ip_address
   subnetwork   = var.bastion_subnet_name
-  region = var.region
+  region       = var.region
 }
 
 resource "google_compute_instance" "default" {
@@ -27,7 +27,7 @@ resource "google_compute_instance" "default" {
   }
 
   service_account {
-    email = "<bastion-service-account-id>"
+    email  = "<bastion-service-account-id>"
     scopes = ["logging-write", "monitoring-write", "storage-ro", "service-management", "service-control", "cloud-platform"]
   }
 

--- a/gcp/gke/gke-terraform-scripts/modules/kubernetes/main.tf
+++ b/gcp/gke/gke-terraform-scripts/modules/kubernetes/main.tf
@@ -1,7 +1,7 @@
 resource "google_container_cluster" "gke-cluster" {
-  project     = var.project_id
-  name     = var.cluster_name
-  location = var.region
+  project    = var.project_id
+  name       = var.cluster_name
+  location   = var.region
   subnetwork = var.subnet_name
 
   # We can't create a cluster with no node pool defined, but we want to only use
@@ -12,7 +12,7 @@ resource "google_container_cluster" "gke-cluster" {
   enable_shielded_nodes    = true
 
   ip_allocation_policy {
-      cluster_ipv4_cidr_block = var.cluster_ipv4_cidr_block
+    cluster_ipv4_cidr_block = var.cluster_ipv4_cidr_block
   }
 
   master_auth {
@@ -21,86 +21,83 @@ resource "google_container_cluster" "gke-cluster" {
     }
   }
 
- master_authorized_networks_config {
-  cidr_blocks {
-    cidr_block = var.bastion_ip
-    display_name = "Bastion Host IP"
+  master_authorized_networks_config {
+    cidr_blocks {
+      cidr_block   = var.bastion_ip
+      display_name = "Bastion Host IP"
+    }
   }
- }
- 
- min_master_version = "1.16.13-gke.401"
 
- network = var.vpc_name
+  min_master_version = "1.16.13-gke.401"
 
- network_policy {
-  enabled = true
- }
+  network = var.vpc_name
 
- private_cluster_config {
-  enable_private_nodes = true
-  enable_private_endpoint = true
-  master_ipv4_cidr_block = var.master_cidr
- }
+  network_policy {
+    enabled = true
+  }
 
+  private_cluster_config {
+    enable_private_nodes    = true
+    enable_private_endpoint = true
+    master_ipv4_cidr_block  = var.master_cidr
+  }
 
 
- vertical_pod_autoscaling {
-  enabled = true
- }
 
- workload_identity_config {
-  identity_namespace = "${var.project_id}.svc.id.goog"
- }
+  vertical_pod_autoscaling {
+    enabled = true
+  }
 
- database_encryption {
-  state = "ENCRYPTED"
-  key_name = var.encryption_key_name
- }
+  workload_identity_config {
+    identity_namespace = "${var.project_id}.svc.id.goog"
+  }
+
+  database_encryption {
+    state    = "ENCRYPTED"
+    key_name = var.encryption_key_name
+  }
 }
 
 resource "google_container_node_pool" "node-pool-1" {
-  name       = "app-node-pool"
-  location   = google_container_cluster.gke-cluster.location
-  cluster    = google_container_cluster.gke-cluster.name
+  name     = "app-node-pool"
+  location = google_container_cluster.gke-cluster.location
+  cluster  = google_container_cluster.gke-cluster.name
   autoscaling {
     min_node_count = 1
     max_node_count = 3
   }
 
   initial_node_count = 1
-  
+
   management {
-    auto_repair = true
-    auto_upgrade = true 
+    auto_repair  = true
+    auto_upgrade = true
   }
 
-  upgrade_settings{
-      max_surge = 1
-      max_unavailable = 0
-    }
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+  }
 
 
   node_config {
-    preemptible  = false
-    machine_type = var.machine_type 
-    disk_size_gb = 20
-    image_type = "COS_CONTAINERD"
+    preemptible     = false
+    machine_type    = var.machine_type
+    disk_size_gb    = 20
+    image_type      = "COS_CONTAINERD"
     service_account = var.service_account_name
 
     shielded_instance_config {
-      enable_secure_boot = true
+      enable_secure_boot          = true
       enable_integrity_monitoring = true
     }
 
     metadata = {
       disable-legacy-endpoints = "true"
-      }
-      
+    }
+
     oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform"
-    ]  
-    }
- }
-
-
-
+    ]
+  }
+}

--- a/gcp/gke/gke-terraform-scripts/modules/kubernetes/main.tf
+++ b/gcp/gke/gke-terraform-scripts/modules/kubernetes/main.tf
@@ -79,7 +79,6 @@ resource "google_container_node_pool" "node-pool-1" {
     max_unavailable = 0
   }
 
-
   node_config {
     preemptible     = false
     machine_type    = var.machine_type

--- a/gcp/gke/gke-terraform-scripts/modules/kubernetes/variables.tf
+++ b/gcp/gke/gke-terraform-scripts/modules/kubernetes/variables.tf
@@ -1,53 +1,53 @@
 variable "project_id" {
-    type = string
-    description = "Project ID"
+  type        = string
+  description = "Project ID"
 }
 
 variable "service_account_name" {
-    type = string
-    description = "name of k8s nodes' service account"
+  type        = string
+  description = "name of k8s nodes' service account"
 }
 
 variable "region" {
-    type = string
-    description = "Regional location of the GKE Cluster."
+  type        = string
+  description = "Regional location of the GKE Cluster."
 }
 
 variable "cluster_name" {
-    type = string
-    description = "Cluster name for the GCP Cluster."
+  type        = string
+  description = "Cluster name for the GCP Cluster."
 }
 variable "vpc_name" {
-    type = string
-    description = "Name of the VPC to deploy GKE cluster on."
+  type        = string
+  description = "Name of the VPC to deploy GKE cluster on."
 }
 variable "subnet_name" {
-    type = string
-    description = "Name of the subnet to deploy GKE cluster on."
+  type        = string
+  description = "Name of the subnet to deploy GKE cluster on."
 }
 
 variable "machine_type" {
-    type = string
-    description = "Defines node configuration"
+  type        = string
+  description = "Defines node configuration"
 }
 
 variable "bastion_ip" {
-    type = string
-    description = "Internal IP address of the Bastion Host VM used to connect to GKE cluster"
+  type        = string
+  description = "Internal IP address of the Bastion Host VM used to connect to GKE cluster"
 }
 
 variable "master_cidr" {
-    type = string
-    description = "CIDR range of GKE Master"
+  type        = string
+  description = "CIDR range of GKE Master"
 }
 
 variable "cluster_ipv4_cidr_block" {
-    type = string
-    description = "CIDR range of pods"
+  type        = string
+  description = "CIDR range of pods"
 }
 
 variable "encryption_key_name" {
-    type = string
-    description = "Name of the encryption key for ETCD"
+  type        = string
+  description = "Name of the encryption key for ETCD"
 }
 

--- a/gcp/gke/gke-terraform-scripts/modules/subnetwork/variables.tf
+++ b/gcp/gke/gke-terraform-scripts/modules/subnetwork/variables.tf
@@ -36,7 +36,7 @@ variable "create_secondary_ranges" {
 * - ip_cidr_range 
 */
 variable "secondary_ranges" {
-  type        = list
+  type        = list(any)
   default     = []
   description = "Create up to 5 alternative CIDR range to represent this subnetwork"
 }

--- a/gcp/gke/gke-terraform-scripts/variables.tf
+++ b/gcp/gke/gke-terraform-scripts/variables.tf
@@ -5,9 +5,9 @@ variable "cred_url" {
 }
 
 variable "service_account_name" {
-    type = string
-    description = "The service account name"
-    default = "<ID of K8s nodes service account>"
+  type        = string
+  description = "The service account name"
+  default     = "<ID of K8s nodes service account>"
 }
 
 variable "project_id" {
@@ -32,100 +32,100 @@ variable "zone" {
 variable "bastion_subnet_name" {
   type        = string
   description = "name of the subnet to deploy bastion host on"
-  default = "admin-subnet"
+  default     = "admin-subnet"
 }
 
 
 variable "gke-vpc" {
-  type              = object({
+  type = object({
+    name = string
+    subnets = list(object({
       name          = string
-      subnets       = list(object({
-                        name          = string
-                        description   = string
-                        ip_cidr_range = string
-                        region        = string
-                      }))
+      description   = string
+      ip_cidr_range = string
+      region        = string
+    }))
   })
   description = "The name of the production VPC"
-  default     = {
-      name          = "gke-vpc"
-      subnets       = [
-            {
-                name          = "admin-subnet"
-                description   = "Subnet for bastion host and other administrative VMs"
-                ip_cidr_range = "10.0.1.0/24"
-                region        = "europe-west2"
-            },
-            {
-                name          = "k8s-nodes-subnet"
-                description   = "Subnet for GKE nodes "
-                ip_cidr_range = "10.0.2.0/24"
-                region        = "europe-west2"
-            }
-      ]
+  default = {
+    name = "gke-vpc"
+    subnets = [
+      {
+        name          = "admin-subnet"
+        description   = "Subnet for bastion host and other administrative VMs"
+        ip_cidr_range = "10.0.1.0/24"
+        region        = "europe-west2"
+      },
+      {
+        name          = "k8s-nodes-subnet"
+        description   = "Subnet for GKE nodes "
+        ip_cidr_range = "10.0.2.0/24"
+        region        = "europe-west2"
+      }
+    ]
   }
 }
 
 
 variable "bastion_host" {
-  type        = object({
-      internal_ip_address = string
-      vm_name             = string
-      machine_type        = string
-      zone                = string
-      machine_image       = string
-      tags                = list(string)
-      bastion_subnet_name = string
-      region = string
+  type = object({
+    internal_ip_address = string
+    vm_name             = string
+    machine_type        = string
+    zone                = string
+    machine_image       = string
+    tags                = list(string)
+    bastion_subnet_name = string
+    region              = string
   })
   description = "The Bastion host config for production"
-  default     = {
-      internal_ip_address = "10.0.1.2"
-      vm_name             = "prod-bastion-host"
-      machine_type        = "n1-standard-1"
-      zone                = "europe-west2-a"
-      machine_image       = "ubuntu-1604-lts"
-      tags                = ["allow-iap"]
-      bastion_subnet_name = "admin-subnet"
-      region = "europe-west2"
+  default = {
+    internal_ip_address = "10.0.1.2"
+    vm_name             = "prod-bastion-host"
+    machine_type        = "n1-standard-1"
+    zone                = "europe-west2-a"
+    machine_image       = "ubuntu-1604-lts"
+    tags                = ["allow-iap"]
+    bastion_subnet_name = "admin-subnet"
+    region              = "europe-west2"
   }
 }
 
 variable "master_cidr" {
-    type = string
-    description = "CIDR block address of GKE master."
-    default = "172.16.0.0/28"
+  type        = string
+  description = "CIDR block address of GKE master."
+  default     = "172.16.0.0/28"
 }
 
 variable "cluster_name" {
-    type = string
-    description = "Cluster name for the GCP Cluster."
-    default = "gke-cluster"
- }
+  type        = string
+  description = "Cluster name for the GCP Cluster."
+  default     = "gke-cluster"
+}
 //GKE CLUSTERS..
 
 variable "gke-cluster" {
-  type        = object({
-      region              = string
-      cluster_name        = string
-      master_cidr         = string
-      cluster_ipv4_cidr_block = string
-      service_account_name = string
-      machine_type = string
+  type = object({
+    region                  = string
+    cluster_name            = string
+    master_cidr             = string
+    cluster_ipv4_cidr_block = string
+    service_account_name    = string
+    machine_type            = string
   })
   description = "The GKE app cluster for production"
-  default     = {
-      region              = "europe-west2"
-      cluster_name        = "gke-cluster"
-      master_cidr         = "172.168.10.0/28"
-      cluster_ipv4_cidr_block = "10.1.0.0/16"
-      service_account_name = "<k8s-nodes-service-account-id>"
-      machine_type = "e2-standard-4"
+  default = {
+    region                  = "europe-west2"
+    cluster_name            = "gke-cluster"
+    master_cidr             = "172.168.10.0/28"
+    cluster_ipv4_cidr_block = "10.1.0.0/16"
+    service_account_name    = "<k8s-nodes-service-account-id>"
+    machine_type            = "e2-standard-4"
   }
 }
 
 variable "encryption_key_name" {
-    type = string
-    description = "Name of the encryption key for ETCD"
-    default = "<encryption-key-id>"
+  type        = string
+  description = "Name of the encryption key for ETCD"
+  default     = "<encryption-key-id>"
 }


### PR DESCRIPTION
`terraform fmt` is the canonical method for formatting Terraform for readability.  I suggest we require the use of this before any PRs are accepted into the project.