### PR TITLE
Evolving CSC Team Roles, Agile Ceremonies and Sprint Cadence

### DIFF
--- a/docs/agile-workflow/README.md
+++ b/docs/agile-workflow/README.md
@@ -1,0 +1,27 @@
+# Cloud Service Certification - Agile Workflow
+
+The Agile Workflow for Cloud Service Certification falls into two main work streams which are overseen by CSC Project Maintainers and fulfilled by the CSC project team and wider FINOS community.
+
+- [Agile Delivery of Prioritised Work Items](#agile)
+- [Community Contributions and Pull Requests](#community)
+
+## <a name="agile">Agile Delivery of Prioritised Work Items</a>
+
+- Cloud Service Certification is an agile project with agreed agile ceremonies and a fixed sprint cadence. Example agile ceremonies include ...
+  - Regular team stand-ups
+  - Backlog grooming sessions
+  - Pre-sprint planning
+  - End of sprint demos
+- Sprint cadence is  **monthly**, as agreed with the CSC project, with end of sprint sessions used for team demos and next-sprint planning.
+- Middle of sprint CSC project meetings also act as stand-ups for team updates and any other discussions / demos to demonstrate completed work and as a forum for helping to remove team blockers.
+- Volunteers from the CSC project form sub-teams around given tasks, epics and stories. Sub-teams own their own deliverables, and method of delivery, from start to finish.
+- Teams self organise for completion of tasks within a given sprint(s), including appointing / aligning with the [Project Operations Manager](https://github.com/finos/cloud-service-certification/pull/99) to help coordinate the team's delivery.
+- Sub-teams swarm around their tasks, epics and stories with self-organised team sessions at the discretion and independent management of the team.
+- Sub-teams collectively review and approve their own work, with final review and approval done at end of sprint demos, with the merge performed by the [CSC Project Maintainers Team](https://github.com/orgs/finos/teams/cloud-cert-maintainers).
+- High level planning of the CSC roadmap happens quarterly, where the next quarter, half and year is reviewed and broken down into sprint priorities.
+- Ad-hoc requests for help are made to the CSC Project Maintainers team which can be tagged using @finos/cloud-cert-maintainers 
+
+## <a name="community">Community Contributions and Pull Requests</a>
+
+- Pull Requests and Issues raised by the FINOS Community are automatically assigned to CSC Project Maintainers and allocated to the CSC project backlog for sprint prioritisation at the next scheduled sprint planning session.
+- Critical Pull Requests and Issues are allocated to the CSC project team for immediate fulfilment at the discretion of the CSC Project Maintainers.


### PR DESCRIPTION
## Description
This pull request adds the content of https://github.com/finos/cloud-service-certification/issues/106#issuecomment-791403129 to the project repo as `docs/agile-workflow/README.md` and closes #106

## Markdown Content
```
# Cloud Service Certification - Agile Workflow

The Agile Workflow for Cloud Service Certification falls into two main work streams which are overseen by CSC Project Maintainers and fulfilled by the CSC project team and wider FINOS community.

- [Agile Delivery of Prioritised Work Items](#agile)
- [Community Contributions and Pull Requests](#community)

## <a name="agile">Agile Delivery of Prioritised Work Items</a>

- Cloud Service Certification is an agile project with agreed agile ceremonies and a fixed sprint cadence. Example agile ceremonies include ...
  - Regular team stand-ups
  - Backlog grooming sessions
  - Pre-sprint planning
  - End of sprint demos
- Sprint cadence is  **monthly**, as agreed with the CSC project, with end of sprint sessions used for team demos and next-sprint planning.
- Middle of sprint CSC project meetings also act as stand-ups for team updates and any other discussions / demos to demonstrate completed work and as a forum for helping to remove team blockers.
- Volunteers from the CSC project form sub-teams around given tasks, epics and stories. Sub-teams own their own deliverables, and method of delivery, from start to finish.
- Teams self organise for completion of tasks within a given sprint(s), including appointing / aligning with the [Project Operations Manager](https://github.com/finos/cloud-service-certification/pull/99) to help coordinate the team's delivery.
- Sub-teams swarm around their tasks, epics and stories with self-organised team sessions at the discretion and independent management of the team.
- Sub-teams collectively review and approve their own work, with final review and approval done at end of sprint demos, with the merge performed by the [CSC Project Maintainers Team](https://github.com/orgs/finos/teams/cloud-cert-maintainers).
- High level planning of the CSC roadmap happens quarterly, where the next quarter, half and year is reviewed and broken down into sprint priorities.
- Ad-hoc requests for help are made to the CSC Project Maintainers team which can be tagged using @finos/cloud-cert-maintainers 

## <a name="community">Community Contributions and Pull Requests</a>

- Pull Requests and Issues raised by the FINOS Community are automatically assigned to CSC Project Maintainers and allocated to the CSC project backlog for sprint prioritisation at the next scheduled sprint planning session.
- Critical Pull Requests and Issues are allocated to the CSC project team for immediate fulfilment at the discretion of the CSC Project Maintainers.
```