### PR TITLE
Update Project Operations Manager role link and Maintainer Team reference

### DIFF
--- a/docs/agile-workflow/README.md
+++ b/docs/agile-workflow/README.md
@@ -15,9 +15,9 @@ The Agile Workflow for Cloud Service Certification falls into two main work stre
 - Sprint cadence is  **monthly**, as agreed with the CSC project, with end of sprint sessions used for team demos and next-sprint planning.
 - Middle of sprint CSC project meetings also act as stand-ups for team updates and any other discussions / demos to demonstrate completed work and as a forum for helping to remove team blockers.
 - Volunteers from the CSC project form sub-teams around given tasks, epics and stories. Sub-teams own their own deliverables, and method of delivery, from start to finish.
-- Teams self organise for completion of tasks within a given sprint(s), including appointing / aligning with the [Project Operations Manager](https://github.com/finos/cloud-service-certification/pull/99) to help coordinate the team's delivery.
+- Teams self organise for completion of tasks within a given sprint(s), including appointing / aligning with the [Project Operations Manager](https://github.com/finos/cloud-service-certification/blob/master/docs/open-roles/project-operations-manager.md) to help coordinate the team's delivery.
 - Sub-teams swarm around their tasks, epics and stories with self-organised team sessions at the discretion and independent management of the team.
-- Sub-teams collectively review and approve their own work, with final review and approval done at end of sprint demos, with the merge performed by the [CSC Project Maintainers Team](https://github.com/orgs/finos/teams/cloud-cert-maintainers).
+- Sub-teams collectively review and approve their own work, with final review and approval done at end of sprint demos, with the merge performed by the CSC Project Maintainers Team - @finos/cloud-cert-maintainers
 - High level planning of the CSC roadmap happens quarterly, where the next quarter, half and year is reviewed and broken down into sprint priorities.
 - Ad-hoc requests for help are made to the CSC Project Maintainers team which can be tagged using @finos/cloud-cert-maintainers 
 


### PR DESCRIPTION
## Description
This is a minor update to the [Project Operations Manager](https://github.com/finos/cloud-service-certification/blob/master/docs/open-roles/project-operations-manager.md) role link and Maintainer Team reference following the merge of #99

## Project Operations Manager Link 
**From** : `https://github.com/finos/cloud-service-certification/pull/99`
**To** : `https://github.com/finos/cloud-service-certification/blob/master/docs/open-roles/project-operations-manager.md`

## Maintainer Team Reference
**From** : `https://github.com/orgs/finos/teams/cloud-cert-maintainers` _(404 if GitHub profile not part of [FINOS Organisation](https://github.com/orgs/finos/people))_
**To** : `@finos/cloud-cert-maintainers`