### PR TITLE
README: Make absolute links to the master branch relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Find the [Cloud Service Certification Project Kanban](https://github.com/orgs/fi
 
 ## Service Approval Accelerator
 
-The [Service Approval Accelerator](https://github.com/finos/cloud-service-certification/blob/master/templates/ServiceApprovalAcceleratorTemplate.md) describes each service contributed to Cloud Service Certification alongside test cases and infrastructure as code.
+The [Service Approval Accelerator](templates/ServiceApprovalAcceleratorTemplate.md) describes each service contributed to Cloud Service Certification alongside test cases and infrastructure as code.
 
-A single [Service Approval Accelerator](https://github.com/finos/cloud-service-certification/blob/master/templates/ServiceApprovalAcceleratorTemplate.md) document should be contributed with every service contributed to Cloud Service Certifcation. 
+A single [Service Approval Accelerator](templates/ServiceApprovalAcceleratorTemplate.md) document should be contributed with every service contributed to Cloud Service Certifcation. 
 
 _See AWS Redshift example below_.
 
@@ -43,11 +43,11 @@ _See AWS Redshift example below_.
 
 The [AWS RedShift Service Definition](https://github.com/finos/cloud-service-certification/tree/master/aws/redshift) has been created to demonstrate through example the assets required with each service contribution to Cloud Service Certification.
 
-* [Redshift Test Cases](https://github.com/finos/cloud-service-certification/blob/master/aws/redshift/RedshiftTestCases.md) : 
+* [Redshift Test Cases](aws/redshift/RedshiftTestCases.md) : 
   * A document containing test cases from the point of view of AWS Redshift. 
-* [Redshift Service Approval Accelerator](https://github.com/finos/cloud-service-certification/blob/master/aws/redshift/ServiceApprovalAcceleratorRedshift.md) : 
+* [Redshift Service Approval Accelerator](aws/redshift/ServiceApprovalAcceleratorRedshift.md) : 
   * A document containing the Service Approval Accelerator from the point of view of AWS Redshift.
-* [The Redshift Service Definition](https://github.com/finos/cloud-service-certification/blob/master/aws/redshift/redshift_template_public.yml) : 
+* [The Redshift Service Definition](aws/redshift/redshift_template_public.yml) : 
   * A YAML file containing the description of the AWS Redshift service as code.
 
 ## CSC Mailing List

--- a/docs/agile-workflow/README.md
+++ b/docs/agile-workflow/README.md
@@ -15,7 +15,7 @@ The Agile Workflow for Cloud Service Certification falls into two main work stre
 - Sprint cadence is  **monthly**, as agreed with the CSC project, with end of sprint sessions used for team demos and next-sprint planning.
 - Middle of sprint CSC project meetings also act as stand-ups for team updates and any other discussions / demos to demonstrate completed work and as a forum for helping to remove team blockers.
 - Volunteers from the CSC project form sub-teams around given tasks, epics and stories. Sub-teams own their own deliverables, and method of delivery, from start to finish.
-- Teams self organise for completion of tasks within a given sprint(s), including appointing / aligning with the [Project Operations Manager](https://github.com/finos/cloud-service-certification/blob/master/docs/open-roles/project-operations-manager.md) to help coordinate the team's delivery.
+- Teams self organise for completion of tasks within a given sprint(s), including appointing / aligning with the [Project Operations Manager](docs/open-roles/project-operations-manager.md) to help coordinate the team's delivery.
 - Sub-teams swarm around their tasks, epics and stories with self-organised team sessions at the discretion and independent management of the team.
 - Sub-teams collectively review and approve their own work, with final review and approval done at end of sprint demos, with the merge performed by the CSC Project Maintainers Team - @finos/cloud-cert-maintainers
 - High level planning of the CSC roadmap happens quarterly, where the next quarter, half and year is reviewed and broken down into sprint priorities.


### PR DESCRIPTION
This helps with:

1. Switching master -> main, since those links would otherwise point nowhere.
2. Forks
3. Clones not on GitHub

Links in GitHub README files should in general be relative, see [the
relevant documentation][1].

[1]: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-readmes#relative-links-and-image-paths-in-readme-files